### PR TITLE
Update taggedTemplates2.js

### DIFF
--- a/esnext/taggedTemplates2.js
+++ b/esnext/taggedTemplates2.js
@@ -4,9 +4,10 @@ function real(partes, ...valores) {
         valor = isNaN(valor) ? valor : `R$${valor.toFixed(2)}`;
         resultado.push(partes[indice], valor);
     });
+    resultado.push(partes[partes.length - 1]);
     return resultado.join('');
 }
 
 const preco = 29.99;
 const precoParcela = 11;
-console.log(real `1x de ${preco} ou 3x de ${precoParcela}`);
+console.log(real `1x de ${preco} ou 3x de ${precoParcela}.`);


### PR DESCRIPTION
O tagged template estava ignorando a última 'partes' após o ${precoParcela}, para isso adicionei a linha 7 no código.